### PR TITLE
Created 'tgicon' variable

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -47,10 +47,11 @@ if (diff <= 0) {
 
 // changing the telegram icon from black to white whenever the user moves his cursor over the button
 const contactUsBTN = document.querySelector("#input-box button");
+const tgicon = contactUsBTN.querySelector("img");
 
 contactUsBTN.addEventListener("mouseover", () => {
-  contactUsBTN.querySelector("img").src = "tgicon_white.png";
+  tgicon.src = "tgicon_white.png";
 })
 contactUsBTN.addEventListener("mouseleave", () => {
-  contactUsBTN.querySelector("img").src = "tgicon_black.png";
+  tgicon.src = "tgicon_black.png";
 })


### PR DESCRIPTION
Without the variable the browser would perform 'querySelector()' everytime the cursor is above and out of the button, for performance purposes saving the search results is better, because i noticed a slight delay in changing to the white icon when the cursor is on the button for the first time